### PR TITLE
updating version nixpkgs to 21.11 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,8 +6,8 @@ in naersk.buildPackage {
   pname = "minimint";
   version = "master";
   src = builtins.fetchGit {
-  url = "https://github.com/fedimint/minimint";
-  ref = "master";
+    url = "https://github.com/fedimint/minimint";
+    ref = "master";
   };
   gitAllRefs = true;
   gitSubmodules = true;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,11 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e5bfe647de809ec361273d2eab25d3cd6919c65",
-        "sha256": "03zfj3chhz0s0ck4v7ma0jz7llm9fpgkysrf0bmppclkwlxrpdk1",
+        "rev": "0e9bebed0c0ed6f15d7c6873df57d463297eb02f",
+        "sha256": "0zqx3cp3g2lylbkvcfbi2sig4lnrx6zsk6j12i92nch8ghpb5hfb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0e5bfe647de809ec361273d2eab25d3cd6919c65.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/0e9bebed0c0ed6f15d7c6873df57d463297eb02f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
+        "version": "21.11"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "nixos-21.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e9bebed0c0ed6f15d7c6873df57d463297eb02f",
-        "sha256": "0zqx3cp3g2lylbkvcfbi2sig4lnrx6zsk6j12i92nch8ghpb5hfb",
+        "rev": "2f06b87f64bc06229e05045853e0876666e1b023",
+        "sha256": "1d7zg96xw4qsqh7c89pgha9wkq3rbi9as3k3d88jlxy2z0ns0cy2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0e9bebed0c0ed6f15d7c6873df57d463297eb02f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2f06b87f64bc06229e05045853e0876666e1b023.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "21.11"
     }


### PR DESCRIPTION
Using nixos-21.11 branch instead of master as it seems to work fine. We will version bump manually when nixpkgs get a version update as master will be pretty unstable.